### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Create a report to help us improve the Cedar policy language extension for Visual Studio Code
+labels: [pending-triage, bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Try to include as much information as you can.
+
+  - type: checkboxes
+    attributes:
+      label: |
+        Before opening, please confirm:
+      options:
+        - label: I have [searched for duplicate or closed issues](https://github.com/cedar-policy/vscode-cedar/issues?q=is%3Aissue+).
+          required: true
+        - label: I have read the guide for [submitting bug reports](https://github.com/cedar-policy/vscode-cedar/blob/main/CONTRIBUTING.md).
+          required: true
+        - label: I have done my best to include a minimal, self-contained set of instructions for consistently reproducing the issue.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Category
+  - type: dropdown
+    attributes:
+      label: Bug Category
+      description: What part of the Cedar policy language extension for Visual Studio Code is this bug related to?
+      multiple: true
+      options:
+        - Cedar Policy Editing
+        - Schemas and Validation
+        - Other
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ## Details
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Reproduction steps
+      description: |
+        How do you trigger this bug? Please walk us through it step by step. Screenshots can be attached in textarea below.
+      placeholder: |
+        1. Open file '...'
+        2. Edit file '...'
+        3. Perform action '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Code Snippet
+      description: |
+        Please provide a code snippet or a link to sample code of the issue you are experiencing to help us reproduce the issue. Please also include relevant Cedar policies, Schemas, or Entity Data.
+
+        **Be sure to remove any sensitive data.**
+      value: |
+        ```
+        // Put your code below this line.
+
+        ```
+  - type: textarea
+    attributes:
+      label: Log output
+      description: |
+        For example, error messages, or stack traces.
+        **Be sure to remove any sensitive data.**
+      value: |
+        ```
+        // Put your output below this line
+
+        ```
+  - type: markdown
+    attributes:
+      value: |
+        ## Configuration
+  - type: textarea
+    attributes:
+      label: Additional configuration
+      description: |
+        If applicable, provide more configuration data (e.g. from .vscode/settings.json).
+        **Be sure to remove any sensitive data**
+
+  - type: input
+    attributes:
+      label: Visual Studio Code version
+      description: from "About Visual Studio Code"
+  - type: input
+    attributes:
+      label: Cedar policy language extension version
+      description: from Extensions inside Visual Studio Code"
+  - type: textarea
+    attributes:
+      label: Additional information and screenshots
+      description: |
+        If you have any additional information, workarounds, etc. for us, use the field below.
+        Please note, you can attach screenshots or screen recordings here by
+        dragging and dropping files in the field below.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Suggest an idea for the Cedar policy language extension for Visual Studio Code
+labels: [pending-triage, feature-request]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submit a feature request! Try to include as much information as you can.
+
+  - type: dropdown
+    attributes:
+      label: Category
+      description: What component of the Cedar policy language extension for Visual Studio Code does this feature relate to?
+      multiple: true
+      options:
+        - Cedar editing features
+        - Cedar validation features
+        - Internal refactors/changes
+        - Documentation and code comments
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the feature you'd like to request
+      description: |
+        A clear and concise description of what you want to happen. Please include **any related issues**, documentation, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered
+      description: |
+        A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: |
+        Add any other use cases or context about the feature request here. Please include any prototype/sandbox, workaround, reference implementation, etc.
+
+  - type: checkboxes
+    attributes:
+      label: Is this something that you'd be interested in working on?
+      options:
+        - label: 👋 I may be able to implement this feature request
+        - label: ⚠️ This feature might incur a breaking change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description of changes
+
+## Issue #, if available
+
+## Checklist for requesting a review
+
+The change in this PR is (choose one, and delete the other options):
+
+- [ ] A breaking change requiring a major version bump to `vscode-cedar`.
+- [ ] A backwards-compatible change requiring a minor version bump to `vscode-cedar`.
+- [ ] A bug fix or other functionality change requiring a patch to `vscode-cedar`.
+- [ ] A change "invisible" to users (e.g., documentation, changes to tests, refactoring, etc.)
+- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.
+
+I confirm that this PR (choose one, and delete the other options):
+
+- [ ] Updates the CHANGELOG with a description of my change (required for version bumps).
+- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.
+
+## Disclaimer
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Add `.github` issue and pull request templates similar to `cedar-policy/cedar` project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
